### PR TITLE
Feature/analytics add feature functions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
             targets: ["AdcioPlacement"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Alamofire/Alamofire.git", Version(5,1,0)..<Version(6,0,0))
+        .package(url: "https://github.com/Alamofire/Alamofire.git", .upToNextMajor(from: "5.8.1"))
     ],
     targets: [
         .target(
@@ -35,6 +35,7 @@ let package = Package(
             name: "AdcioAnalytics",
             dependencies: [
                 .product(name: "Alamofire", package: "Alamofire"),
+                .target(name: "AdcioCore")
             ]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "AdcioCore",
+    name: "AdcioOpenSDK",
     platforms: [
         .iOS(.v13)
     ],

--- a/Sources/AdcioAnalytics/AdcioAnalytics.swift
+++ b/Sources/AdcioAnalytics/AdcioAnalytics.swift
@@ -4,7 +4,7 @@
 import Foundation
 import AdcioCore
 
-private let BASE_URL = "https://receiver-dev.adcio.ai/"
+private let baseUrl = "https://receiver.adcio.ai/"
 
 public final class AdcioAnalytics {
     public static let shared = AdcioAnalytics()
@@ -19,12 +19,12 @@ public final class AdcioAnalytics {
     
     public func onClick(
         option: AdcioLogOption,
-        baseUrl: String? = nil,
+        baseUrl url: String? = nil,
         onSuccess: ((Data) -> Void)? = nil,
         onFailure: @escaping (Error) -> Void
     ) {
         PerformanceAPI.shared.callPerformance(
-            "\(baseUrl ?? BASE_URL)performance/click",
+            "\(url ?? baseUrl)performance/click",
             requestId: option.requestId,
             adsetId: option.adsetId,
             onSuccess: { data in
@@ -40,14 +40,14 @@ public final class AdcioAnalytics {
     
     public func onImpression(
         option: AdcioLogOption,
-        baseUrl: String? = nil,
+        baseUrl url: String? = nil,
         onSuccess: ((Data) -> Void)? = nil,
         onFailure: @escaping (Error) -> Void
     ) {
         impressionHistory.append(option.adsetId)
         
         PerformanceAPI.shared.callPerformance(
-            "\(baseUrl ?? BASE_URL)performance/impression",
+            "\(url ?? baseUrl)performance/impression",
             requestId: option.requestId,
             adsetId: option.adsetId,
             onSuccess: { data in
@@ -69,12 +69,12 @@ public final class AdcioAnalytics {
         deviceId: String? = nil,
         storeId: String? = nil,
         customerId: String? = nil,
-        baseUrl: String? = nil,
+        baseUrl url: String? = nil,
         onSuccess: ((Data) -> Void)? = nil,
         onFailure: @escaping (Error) -> Void
     ) throws {
         EventAPI.shared.callPurchaseEvent(
-            "\(baseUrl ?? BASE_URL)events/purchase",
+            "\(url ?? baseUrl)events/purchase",
             sessionId: try sessionId ?? AdcioCore.shared.sessionId(),
             deviceId: try deviceId ?? AdcioCore.shared.deviceId(),
             storeId: try storeId ?? AdcioCore.shared.storeId,
@@ -102,12 +102,12 @@ public final class AdcioAnalytics {
         customerId: String? = nil,
         productIdOnStore: String? = nil,
         referrer: String? = nil,
-        baseUrl: String? = nil,
+        baseUrl url: String? = nil,
         onSuccess: ((Data) -> Void)? = nil,
         onFailure: @escaping (Error) -> Void
     ) throws {
         EventAPI.shared.callPageViewEvent(
-            "\(baseUrl ?? BASE_URL)events/view",
+            "\(url ?? baseUrl)events/view",
             sessionId: try sessionId ?? AdcioCore.shared.sessionId(),
             deviceId: try deviceId ?? AdcioCore.shared.deviceId(),
             storeId: try storeId ?? AdcioCore.shared.storeId,
@@ -134,12 +134,12 @@ public final class AdcioAnalytics {
         deviceId: String? = nil,
         storeId: String? = nil,
         customerId: String? = nil,
-        baseUrl: String? = nil,
+        baseUrl url: String? = nil,
         onSuccess: ((Data) -> Void)? = nil,
         onFailure: @escaping (Error) -> Void
     ) throws {
         EventAPI.shared.callAddToCartEvent(
-            "\(baseUrl ?? BASE_URL)events/add-to-cart",
+            "\(url ?? baseUrl)events/add-to-cart",
             sessionId: try sessionId ?? AdcioCore.shared.sessionId(),
             deviceId: try deviceId ?? AdcioCore.shared.deviceId(),
             cartId: cartId,

--- a/Sources/AdcioAnalytics/AdcioAnalytics.swift
+++ b/Sources/AdcioAnalytics/AdcioAnalytics.swift
@@ -2,6 +2,7 @@
 // https://docs.swift.org/swift-book
 
 import Foundation
+import AdcioCore
 
 private let BASE_URL = "https://receiver-dev.adcio.ai/"
 
@@ -50,11 +51,15 @@ public final class AdcioAnalytics {
         customerId: String? = nil,
         baseUrl: String? = nil
     ) {
+        lazy var sessionIdValue: String = try! AdcioCore.shared.sessionId()
+        lazy var deviceIdValue: String = try! AdcioCore.shared.deviceId()
+        lazy var storeIdValue: String = try! AdcioCore.shared.storeId
+        
         EventAPI.shared.callPurchaseEvent(
             "\(baseUrl ?? BASE_URL)events/purchase",
-            sessionId: sessionId ?? "SAMPLE SESSION ID",
-            deviceId: deviceId ?? "SAMPLE DEVICE ID",
-            storeId: storeId ?? "SAMPLE STORE ID",
+            sessionId: sessionId ?? sessionIdValue,
+            deviceId: deviceId ?? deviceIdValue,
+            storeId: storeId ?? storeIdValue,
             orderId: orderId,
             productIdOnStore: productIdOnStore,
             amount: amount,
@@ -73,11 +78,15 @@ public final class AdcioAnalytics {
         referrer: String? = nil,
         baseUrl: String? = nil
     ) {
+        lazy var sessionIdValue: String = try! AdcioCore.shared.sessionId()
+        lazy var deviceIdValue: String = try! AdcioCore.shared.deviceId()
+        lazy var storeIdValue: String = try! AdcioCore.shared.storeId
+        
         EventAPI.shared.callPageViewEvent(
             "\(baseUrl ?? BASE_URL)events/view",
-            sessionId: sessionId ?? "SAMPLE SESSION ID" ,
-            deviceId: deviceId ?? "SAMPLE DEVICE ID",
-            storeId: storeId ?? "SAMPLE STORE ID",
+            sessionId: sessionId ?? sessionIdValue,
+            deviceId: deviceId ?? deviceIdValue,
+            storeId: storeId ?? storeIdValue,
             path: path,
             customerId: customerId,
             productIdOnStore: productIdOnStore,
@@ -95,12 +104,16 @@ public final class AdcioAnalytics {
         customerId: String? = nil,
         baseUrl: String? = nil
     ) {
+        lazy var sessionIdValue: String = try! AdcioCore.shared.sessionId()
+        lazy var deviceIdValue: String = try! AdcioCore.shared.deviceId()
+        lazy var storeIdValue: String = try! AdcioCore.shared.storeId
+        
         EventAPI.shared.callAddToCartEvent(
             "\(baseUrl ?? BASE_URL)events/add-to-cart",
-            sessionId: sessionId ?? "SAMPLE SESSION ID",
-            deviceId: deviceId ?? "SAMPLE DEVICE ID",
+            sessionId: sessionId ?? sessionIdValue,
+            deviceId: deviceId ?? deviceIdValue,
             cartId: cartId,
-            storeId: storeId ?? "SAMPLE STORE ID",
+            storeId: storeId ?? storeIdValue,
             productIdOnStore: productIdOnStore,
             customerId: customerId
         )

--- a/Sources/AdcioAnalytics/AdcioAnalytics.swift
+++ b/Sources/AdcioAnalytics/AdcioAnalytics.swift
@@ -19,25 +19,45 @@ public final class AdcioAnalytics {
     
     public func onClick(
         option: AdcioLogOption,
-        baseUrl: String? = nil
+        baseUrl: String? = nil,
+        onSuccess: ((Data) -> Void)? = nil,
+        onFailure: @escaping (Error) -> Void
     ) {
         PerformanceAPI.shared.callPerformance(
             "\(baseUrl ?? BASE_URL)performance/click",
             requestId: option.requestId,
-            adsetId: option.adsetId
+            adsetId: option.adsetId,
+            onSuccess: { data in
+                if let onSuccess = onSuccess {
+                    onSuccess(data)
+                }
+            },
+            onFailure: { error in
+                onFailure(error)
+            }
         )
     }
     
     public func onImpression(
         option: AdcioLogOption,
-        baseUrl: String? = nil
+        baseUrl: String? = nil,
+        onSuccess: ((Data) -> Void)? = nil,
+        onFailure: @escaping (Error) -> Void
     ) {
         impressionHistory.append(option.adsetId)
         
         PerformanceAPI.shared.callPerformance(
             "\(baseUrl ?? BASE_URL)performance/impression",
             requestId: option.requestId,
-            adsetId: option.adsetId
+            adsetId: option.adsetId,
+            onSuccess: { data in
+                if let onSuccess = onSuccess {
+                    onSuccess(data)
+                }
+            },
+            onFailure: { error in
+                onFailure(error)
+            }
         )
     }
     
@@ -49,7 +69,9 @@ public final class AdcioAnalytics {
         deviceId: String? = nil,
         storeId: String? = nil,
         customerId: String? = nil,
-        baseUrl: String? = nil
+        baseUrl: String? = nil,
+        onSuccess: ((Data) -> Void)? = nil,
+        onFailure: @escaping (Error) -> Void
     ) {
         lazy var sessionIdValue: String = try! AdcioCore.shared.sessionId()
         lazy var deviceIdValue: String = try! AdcioCore.shared.deviceId()
@@ -63,7 +85,15 @@ public final class AdcioAnalytics {
             orderId: orderId,
             productIdOnStore: productIdOnStore,
             amount: amount,
-            customerId: customerId
+            customerId: customerId,
+            onSuccess: { data in
+                if let onSuccess = onSuccess {
+                    onSuccess(data)
+                }
+            },
+            onFailure: { error in
+                onFailure(error)
+            }
         )
     }
     
@@ -76,7 +106,9 @@ public final class AdcioAnalytics {
         customerId: String? = nil,
         productIdOnStore: String? = nil,
         referrer: String? = nil,
-        baseUrl: String? = nil
+        baseUrl: String? = nil,
+        onSuccess: ((Data) -> Void)? = nil,
+        onFailure: @escaping (Error) -> Void
     ) {
         lazy var sessionIdValue: String = try! AdcioCore.shared.sessionId()
         lazy var deviceIdValue: String = try! AdcioCore.shared.deviceId()
@@ -91,7 +123,15 @@ public final class AdcioAnalytics {
             customerId: customerId,
             productIdOnStore: productIdOnStore,
             title: title ?? path,
-            referrer: referrer
+            referrer: referrer,
+            onSuccess: { data in
+                if let onSuccess = onSuccess {
+                    onSuccess(data)
+                }
+            },
+            onFailure: { error in
+                onFailure(error)
+            }
         )
     }
     
@@ -102,7 +142,9 @@ public final class AdcioAnalytics {
         deviceId: String? = nil,
         storeId: String? = nil,
         customerId: String? = nil,
-        baseUrl: String? = nil
+        baseUrl: String? = nil,
+        onSuccess: ((Data) -> Void)? = nil,
+        onFailure: @escaping (Error) -> Void
     ) {
         lazy var sessionIdValue: String = try! AdcioCore.shared.sessionId()
         lazy var deviceIdValue: String = try! AdcioCore.shared.deviceId()
@@ -115,7 +157,15 @@ public final class AdcioAnalytics {
             cartId: cartId,
             storeId: storeId ?? storeIdValue,
             productIdOnStore: productIdOnStore,
-            customerId: customerId
+            customerId: customerId,
+            onSuccess: { data in
+                if let onSuccess = onSuccess {
+                    onSuccess(data)
+                }
+            },
+            onFailure: { error in
+                onFailure(error)
+            }
         )
     }
 }

--- a/Sources/AdcioAnalytics/AdcioAnalytics.swift
+++ b/Sources/AdcioAnalytics/AdcioAnalytics.swift
@@ -72,16 +72,12 @@ public final class AdcioAnalytics {
         baseUrl: String? = nil,
         onSuccess: ((Data) -> Void)? = nil,
         onFailure: @escaping (Error) -> Void
-    ) {
-        lazy var sessionIdValue: String = try! AdcioCore.shared.sessionId()
-        lazy var deviceIdValue: String = try! AdcioCore.shared.deviceId()
-        lazy var storeIdValue: String = try! AdcioCore.shared.storeId
-        
+    ) throws {
         EventAPI.shared.callPurchaseEvent(
             "\(baseUrl ?? BASE_URL)events/purchase",
-            sessionId: sessionId ?? sessionIdValue,
-            deviceId: deviceId ?? deviceIdValue,
-            storeId: storeId ?? storeIdValue,
+            sessionId: try sessionId ?? AdcioCore.shared.sessionId(),
+            deviceId: try deviceId ?? AdcioCore.shared.deviceId(),
+            storeId: try storeId ?? AdcioCore.shared.storeId,
             orderId: orderId,
             productIdOnStore: productIdOnStore,
             amount: amount,
@@ -109,16 +105,12 @@ public final class AdcioAnalytics {
         baseUrl: String? = nil,
         onSuccess: ((Data) -> Void)? = nil,
         onFailure: @escaping (Error) -> Void
-    ) {
-        lazy var sessionIdValue: String = try! AdcioCore.shared.sessionId()
-        lazy var deviceIdValue: String = try! AdcioCore.shared.deviceId()
-        lazy var storeIdValue: String = try! AdcioCore.shared.storeId
-        
+    ) throws {
         EventAPI.shared.callPageViewEvent(
             "\(baseUrl ?? BASE_URL)events/view",
-            sessionId: sessionId ?? sessionIdValue,
-            deviceId: deviceId ?? deviceIdValue,
-            storeId: storeId ?? storeIdValue,
+            sessionId: try sessionId ?? AdcioCore.shared.sessionId(),
+            deviceId: try deviceId ?? AdcioCore.shared.deviceId(),
+            storeId: try storeId ?? AdcioCore.shared.storeId,
             path: path,
             customerId: customerId,
             productIdOnStore: productIdOnStore,
@@ -145,17 +137,13 @@ public final class AdcioAnalytics {
         baseUrl: String? = nil,
         onSuccess: ((Data) -> Void)? = nil,
         onFailure: @escaping (Error) -> Void
-    ) {
-        lazy var sessionIdValue: String = try! AdcioCore.shared.sessionId()
-        lazy var deviceIdValue: String = try! AdcioCore.shared.deviceId()
-        lazy var storeIdValue: String = try! AdcioCore.shared.storeId
-        
+    ) throws {
         EventAPI.shared.callAddToCartEvent(
             "\(baseUrl ?? BASE_URL)events/add-to-cart",
-            sessionId: sessionId ?? sessionIdValue,
-            deviceId: deviceId ?? deviceIdValue,
+            sessionId: try sessionId ?? AdcioCore.shared.sessionId(),
+            deviceId: try deviceId ?? AdcioCore.shared.deviceId(),
             cartId: cartId,
-            storeId: storeId ?? storeIdValue,
+            storeId: try storeId ?? AdcioCore.shared.storeId,
             productIdOnStore: productIdOnStore,
             customerId: customerId,
             onSuccess: { data in

--- a/Sources/AdcioAnalytics/AdcioAnalytics.swift
+++ b/Sources/AdcioAnalytics/AdcioAnalytics.swift
@@ -1,2 +1,108 @@
 // The Swift Programming Language
 // https://docs.swift.org/swift-book
+
+import Foundation
+
+private let BASE_URL = "https://receiver-dev.adcio.ai/"
+
+public final class AdcioAnalytics {
+    public static let shared = AdcioAnalytics()
+    
+    private init() {}
+    
+    private var impressionHistory: [String] = []
+    
+    public func clearImpressionHistory() {
+        impressionHistory.removeAll()
+    }
+    
+    public func onClick(
+        option: AdcioLogOption,
+        baseUrl: String? = nil
+    ) {
+        PerformanceAPI.shared.callPerformance(
+            "\(baseUrl ?? BASE_URL)performance/click",
+            requestId: option.requestId,
+            adsetId: option.adsetId
+        )
+    }
+    
+    public func onImpression(
+        option: AdcioLogOption,
+        baseUrl: String? = nil
+    ) {
+        impressionHistory.append(option.adsetId)
+        
+        PerformanceAPI.shared.callPerformance(
+            "\(baseUrl ?? BASE_URL)performance/impression",
+            requestId: option.requestId,
+            adsetId: option.adsetId
+        )
+    }
+    
+    public func onPurchase(
+        orderId: String,
+        productIdOnStore: String,
+        amount: Int,
+        sessionId: String? = nil,
+        deviceId: String? = nil,
+        storeId: String? = nil,
+        customerId: String? = nil,
+        baseUrl: String? = nil
+    ) {
+        EventAPI.shared.callPurchaseEvent(
+            "\(baseUrl ?? BASE_URL)events/purchase",
+            sessionId: sessionId ?? "SAMPLE SESSION ID",
+            deviceId: deviceId ?? "SAMPLE DEVICE ID",
+            storeId: storeId ?? "SAMPLE STORE ID",
+            orderId: orderId,
+            productIdOnStore: productIdOnStore,
+            amount: amount,
+            customerId: customerId
+        )
+    }
+    
+    public func onPageView(
+        path: String,
+        sessionId: String? = nil,
+        deviceId: String? = nil,
+        storeId: String? = nil,
+        title: String? = nil,
+        customerId: String? = nil,
+        productIdOnStore: String? = nil,
+        referrer: String? = nil,
+        baseUrl: String? = nil
+    ) {
+        EventAPI.shared.callPageViewEvent(
+            "\(baseUrl ?? BASE_URL)events/view",
+            sessionId: sessionId ?? "SAMPLE SESSION ID" ,
+            deviceId: deviceId ?? "SAMPLE DEVICE ID",
+            storeId: storeId ?? "SAMPLE STORE ID",
+            path: path,
+            customerId: customerId,
+            productIdOnStore: productIdOnStore,
+            title: title ?? path,
+            referrer: referrer
+        )
+    }
+    
+    public func onAddToCart(
+        cartId: String,
+        productIdOnStore: String,
+        sessionId: String? = nil,
+        deviceId: String? = nil,
+        storeId: String? = nil,
+        customerId: String? = nil,
+        baseUrl: String? = nil
+    ) {
+        EventAPI.shared.callAddToCartEvent(
+            "\(baseUrl ?? BASE_URL)events/add-to-cart",
+            sessionId: sessionId ?? "SAMPLE SESSION ID",
+            deviceId: deviceId ?? "SAMPLE DEVICE ID",
+            cartId: cartId,
+            storeId: storeId ?? "SAMPLE STORE ID",
+            productIdOnStore: productIdOnStore,
+            customerId: customerId
+        )
+    }
+}

--- a/Sources/AdcioAnalytics/Errors/AdcioNetworkError.swift
+++ b/Sources/AdcioAnalytics/Errors/AdcioNetworkError.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 public enum AdcioNetworkError: Error {
-    case unregisteredIdError
     case serverError
     case platformError(statusCode: Int, message: String)
+    case emptyStatusCodeError(message: String)
 }

--- a/Sources/AdcioAnalytics/Errors/AdcioNetworkError.swift
+++ b/Sources/AdcioAnalytics/Errors/AdcioNetworkError.swift
@@ -1,0 +1,14 @@
+//
+//  AdcioNetworkError.swift
+//
+//
+//  Created by 최민재 on 10/30/23.
+//
+
+import Foundation
+
+public enum AdcioNetworkError: Error {
+    case unregisteredIdError
+    case serverError
+    case platformError(statusCode: Int, message: String)
+}

--- a/Sources/AdcioAnalytics/Errors/JsonError.swift
+++ b/Sources/AdcioAnalytics/Errors/JsonError.swift
@@ -9,5 +9,5 @@ import Foundation
 
 public enum JsonError: Error {
     case failedParsingJsonError(message: String)
-    case noDataAvailable
+    case noDataAvailable(message: String)
 }

--- a/Sources/AdcioAnalytics/Errors/JsonError.swift
+++ b/Sources/AdcioAnalytics/Errors/JsonError.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//  
+//
+//  Created by 최민재 on 10/30/23.
+//
+
+import Foundation
+
+public enum JsonError: Error {
+    case failedParsingJsonError(message: String)
+    case noDataAvailable
+}

--- a/Sources/AdcioAnalytics/Model/AdcioLogOption.swift
+++ b/Sources/AdcioAnalytics/Model/AdcioLogOption.swift
@@ -7,7 +7,12 @@
 
 import Foundation
 
-public struct AdcioLogOption: Equatable {
-    let requestId: String
-    let adsetId: String
+public struct AdcioLogOption {
+    public var requestId: String
+    public var adsetId: String
+    
+    public init(requestId: String, adsetId: String) {
+        self.requestId = requestId
+        self.adsetId = adsetId
+    }
 }

--- a/Sources/AdcioAnalytics/Model/AdcioLogOption.swift
+++ b/Sources/AdcioAnalytics/Model/AdcioLogOption.swift
@@ -1,0 +1,13 @@
+//
+//  AdcioLogOption.swift
+//
+//
+//  Created by 최민재 on 10/26/23.
+//
+
+import Foundation
+
+public struct AdcioLogOption: Equatable {
+    let requestId: String
+    let adsetId: String
+}

--- a/Sources/AdcioAnalytics/Network/API/EventAPI.swift
+++ b/Sources/AdcioAnalytics/Network/API/EventAPI.swift
@@ -1,0 +1,89 @@
+//
+//  EventAPI.swift
+//
+//
+//  Created by 최민재 on 10/25/23.
+//
+
+import Foundation
+
+final class EventAPI {
+    static let shared = EventAPI()
+    
+    private init() {}
+    
+    func callPageViewEvent(
+        _ url: String,
+        sessionId: String,
+        deviceId: String,
+        storeId: String,
+        path: String,
+        customerId: String? = nil,
+        productIdOnStore: String? = nil,
+        title: String? = nil,
+        referrer: String? = nil
+    ) {
+        var parameters: [String : Any] = [:]
+        parameters["sessionId"] = sessionId
+        parameters["deviceId"] = deviceId
+        parameters["storeId"] = storeId
+        parameters["path"] = path
+        if customerId != nil { parameters["customerId"] = customerId }
+        if productIdOnStore != nil { parameters["productIdOnStore"] = productIdOnStore }
+        if title != nil { parameters["title"] = title }
+        if referrer != nil { parameters["referrer"] = referrer }
+        
+        APIManager.request(
+            url,
+            parameters: parameters
+        )
+    }
+    
+    func callPurchaseEvent(
+        _ url: String,
+        sessionId: String,
+        deviceId: String,
+        storeId: String,
+        orderId: String,
+        productIdOnStore: String,
+        amount: Int,
+        customerId: String? = nil
+    ) {
+        var parameters: [String : Any] = [:]
+        parameters["sessionId"] = sessionId
+        parameters["deviceId"] = deviceId
+        parameters["storeId"] = storeId
+        parameters["orderId"] = orderId
+        parameters["productIdOnStore"] = productIdOnStore
+        parameters["amount"] = amount
+        if customerId != nil { parameters["customerId"] = customerId }
+        
+        APIManager.request(
+            url,
+            parameters: parameters
+        )
+    }
+    
+    func callAddToCartEvent(
+        _ url: String,
+        sessionId: String,
+        deviceId: String,
+        cartId: String,
+        storeId: String,
+        productIdOnStore: String,
+        customerId: String? = nil
+    ) {
+        var parameters: [String : Any] = [:]
+        parameters["sessionId"] = sessionId
+        parameters["deviceId"] = deviceId
+        parameters["cartId"] = cartId
+        parameters["storeId"] = storeId
+        parameters["productIdOnStore"] = productIdOnStore
+        if customerId != nil { parameters["customerId"] = customerId }
+        
+        APIManager.request(
+            url,
+            parameters: parameters
+        )
+    }
+}

--- a/Sources/AdcioAnalytics/Network/API/EventAPI.swift
+++ b/Sources/AdcioAnalytics/Network/API/EventAPI.swift
@@ -21,7 +21,9 @@ final class EventAPI {
         customerId: String? = nil,
         productIdOnStore: String? = nil,
         title: String? = nil,
-        referrer: String? = nil
+        referrer: String? = nil,
+        onSuccess: ((Data) -> Void)? = nil,
+        onFailure: @escaping (Error) -> Void
     ) {
         var parameters: [String : Any] = [:]
         parameters["sessionId"] = sessionId
@@ -35,7 +37,19 @@ final class EventAPI {
         
         APIManager.request(
             url,
-            parameters: parameters
+            parameters: parameters,
+            completion: { result in
+                switch result {
+                case .success(let data):
+                    // success
+                    if let onSuccess = onSuccess {
+                        onSuccess(data)
+                    }
+                case .failure(let error):
+                    // error
+                    onFailure(error)
+                }
+            }
         )
     }
     
@@ -47,7 +61,9 @@ final class EventAPI {
         orderId: String,
         productIdOnStore: String,
         amount: Int,
-        customerId: String? = nil
+        customerId: String? = nil,
+        onSuccess: ((Data) -> Void)? = nil,
+        onFailure: @escaping (Error) -> Void
     ) {
         var parameters: [String : Any] = [:]
         parameters["sessionId"] = sessionId
@@ -60,7 +76,19 @@ final class EventAPI {
         
         APIManager.request(
             url,
-            parameters: parameters
+            parameters: parameters,
+            completion: { result in
+                switch result {
+                case .success(let data):
+                    // success
+                    if let onSuccess = onSuccess {
+                        onSuccess(data)
+                    }
+                case .failure(let error):
+                    // error
+                    onFailure(error)
+                }
+            }
         )
     }
     
@@ -71,7 +99,9 @@ final class EventAPI {
         cartId: String,
         storeId: String,
         productIdOnStore: String,
-        customerId: String? = nil
+        customerId: String? = nil,
+        onSuccess: ((Data) -> Void)? = nil,
+        onFailure: @escaping (Error) -> Void
     ) {
         var parameters: [String : Any] = [:]
         parameters["sessionId"] = sessionId
@@ -83,7 +113,19 @@ final class EventAPI {
         
         APIManager.request(
             url,
-            parameters: parameters
+            parameters: parameters,
+            completion: { result in
+                switch result {
+                case .success(let data):
+                    // success
+                    if let onSuccess = onSuccess {
+                        onSuccess(data)
+                    }
+                case .failure(let error):
+                    // error
+                    onFailure(error)
+                }
+            }
         )
     }
 }

--- a/Sources/AdcioAnalytics/Network/API/PerformanceAPI.swift
+++ b/Sources/AdcioAnalytics/Network/API/PerformanceAPI.swift
@@ -1,0 +1,29 @@
+//
+//  PerformanceAPI.swift
+//
+//
+//  Created by 최민재 on 10/26/23.
+//
+
+import Foundation
+
+final class PerformanceAPI {
+    static let shared = PerformanceAPI()
+    
+    private init() {}
+    
+    func callPerformance(
+        _ url: String,
+        requestId: String,
+        adsetId: String
+    ) {
+        var parameters: [String : Any] = [:]
+        parameters["requestId"] = requestId
+        parameters["adsetId"] = adsetId
+        
+        APIManager.request(
+            url,
+            parameters: parameters
+        )
+    }
+}

--- a/Sources/AdcioAnalytics/Network/API/PerformanceAPI.swift
+++ b/Sources/AdcioAnalytics/Network/API/PerformanceAPI.swift
@@ -15,7 +15,9 @@ final class PerformanceAPI {
     func callPerformance(
         _ url: String,
         requestId: String,
-        adsetId: String
+        adsetId: String,
+        onSuccess: ((Data) -> Void)? = nil,
+        onFailure: @escaping (Error) -> Void
     ) {
         var parameters: [String : Any] = [:]
         parameters["requestId"] = requestId
@@ -23,7 +25,19 @@ final class PerformanceAPI {
         
         APIManager.request(
             url,
-            parameters: parameters
+            parameters: parameters,
+            completion: { result in
+                switch result {
+                case .success(let data):
+                    // success
+                    if let onSuccess = onSuccess {
+                        onSuccess(data)
+                    }
+                case .failure(let error):
+                    // error
+                    onFailure(error)
+                }
+            }
         )
     }
 }

--- a/Sources/AdcioAnalytics/Network/APIManager.swift
+++ b/Sources/AdcioAnalytics/Network/APIManager.swift
@@ -16,8 +16,9 @@ class APIManager {
         method: HTTPMethod = .post,
         parameters: Parameters? = nil,
         headers: HTTPHeaders? = ["Content-Type": "application/json"],
-        encoding: ParameterEncoding = JSONEncoding.default
-    ) throws {
+        encoding: ParameterEncoding = JSONEncoding.default,
+        completion: @escaping (Result<Data, Error>) -> Void
+    )  {
         let request = AF.request(
             url,
             method: method,
@@ -29,13 +30,16 @@ class APIManager {
         request.responseData { response in
             if case .success(let data) = response.result {
                 
-                guard let statusCode = response.response?.statusCode else { // TODO: throw
-                    throw AdcioNetworkError.unregisteredIdError
+                guard let statusCode = response.response?.statusCode else {
+                    completion(.failure(AdcioNetworkError.emptyStatusCodeError(message: "Unkown statusCode")))
+                    return
                 }
                 
                 // success case
                 if [200, 201].contains(statusCode) {
-                    return debugPrint("\(Date()) - \(url) : \(method) request success")
+                    completion(.success(data))
+                    debugPrint("\(Date()) - \(url) : \(method) request success")
+                    return
                 }
                 // error case
                 if (300...499).contains(statusCode) {
@@ -44,22 +48,27 @@ class APIManager {
                     do {
                         errorData = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
                     } catch {
-                        throw JsonError.failedParsingJsonError(message: "Json parsing failed.")
+                        completion(.failure(JsonError.failedParsingJsonError(message: "Unable parse JSON")))
+                        return
                     }
                     
                     // resultJson non-nil
                     guard let errorJson = errorData else {
-                        throw JsonError.noDataAvailable
+                        completion(.failure(JsonError.noDataAvailable(message: "Empty JSON")))
+                        return
                     }
                     
-                    throw AdcioNetworkError.platformError(
-                        statusCode: errorJson["statusCode"] as? Int ?? 400,
-                        message: errorJson["message"] as? String ?? "Unknown error occured.")
+                    completion(.failure(AdcioNetworkError.platformError(
+                        statusCode: statusCode,
+                        message: errorJson["message"] as? String ?? "Unkown Error"
+                    )))
                     
                     debugPrint("\(Date()) - \(url) : \(method) Error request - statusCode(\(statusCode))")
+                    return
                 }
-            } else if case .failure(let error) = response.result {
-                throw AdcioNetworkError.serverError
+            } else if case .failure(_) = response.result {
+                completion(.failure(AdcioNetworkError.serverError))
+                return
             }
         }
         

--- a/Sources/AdcioAnalytics/Network/APIManager.swift
+++ b/Sources/AdcioAnalytics/Network/APIManager.swift
@@ -18,22 +18,39 @@ class APIManager {
         headers: HTTPHeaders? = ["Content-Type": "application/json"],
         encoding: ParameterEncoding = JSONEncoding.default
     ) {
-        AF.request(
+        let request = AF.request(
             url,
             method: method,
             parameters: parameters,
             encoding: encoding,
             headers: headers
-        ) {
-            $0.timeoutInterval = 15
-        }.responseJSON { response in
+        )
+        request.responseData { response in
             switch response.result {
-            case.success:q
-                print("\(Date()) - \(url) : 성공")
+            case .success(let data):
+                do {
+                    let resultJSON = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+                    if let resultJSON = resultJSON {
+                        if let statusCode = resultJSON["statusCode"] as? Int {
+                            if (300...499).contains(statusCode) {
+                                debugPrint("\(Date()) - \(url) : \(method) Error request - statusCode(\(statusCode))")
+                            } else if (200...299).contains(statusCode) {
+                                debugPrint("\(Date()) - \(url) : \(method) request success - statusCode(\(statusCode))")
+                            }
+                        } else {
+                            if resultJSON.keys.contains("success") {
+                                debugPrint("\(Date()) - \(url) : \(method) request success")
+                            }
+                        }
+                        dump(resultJSON)
+                    }
+                } catch {
+                    debugPrint("Error while decoding response: \(error) from: \(data)")
+                }
             
             case .failure(let error):
+                debugPrint("\(Date()) - \(url) : \(method) Error request")
                 dump(error)
-                break
             }
         }
         

--- a/Sources/AdcioAnalytics/Network/APIManager.swift
+++ b/Sources/AdcioAnalytics/Network/APIManager.swift
@@ -1,0 +1,41 @@
+//
+//  APIManager.swift
+//  AdcioAnalytics
+//
+//  Created by 최민재 on 10/25/23.
+//
+
+import Foundation
+import Alamofire
+
+class APIManager {
+    let decoder = JSONDecoder()
+    
+    static func request(
+        _ url: String,
+        method: HTTPMethod = .post,
+        parameters: Parameters? = nil,
+        headers: HTTPHeaders? = ["Content-Type": "application/json"],
+        encoding: ParameterEncoding = JSONEncoding.default
+    ) {
+        AF.request(
+            url,
+            method: method,
+            parameters: parameters,
+            encoding: encoding,
+            headers: headers
+        ) {
+            $0.timeoutInterval = 15
+        }.responseJSON { response in
+            switch response.result {
+            case.success:q
+                print("\(Date()) - \(url) : 성공")
+            
+            case .failure(let error):
+                dump(error)
+                break
+            }
+        }
+        
+    }
+}


### PR DESCRIPTION
## :pushpin: Type of PR
feature

## :recycle: Current situation
* Network 통신 함수 추가.
* 패키지 기본 entity 추가. (AdcioLogOption)
* 사용자가 사용할 함수 추가.

## :bulb: Proposed solution
* 28f858895be4670ce31082d1c338c820ab033497 : 전 Repository의 개발된 부분 가져오기.
  * 사용자 함수, APIManager, Entity 기본적인 구현은 모두 완료되어있었습니다.
* b114ccf0bef77d779c13004bf2bb1bb5e872b7cd : 전체 페키지들을 묶어서 부를 이름 설정.
  * Kakao SDK의 KakaoOpenSDK 참고하여 AdcioOpenSDK로 명명
  * 혹시 더 좋은 이름이 있다면 코맨트 부탁드립니다!
  * PR과 상관 없는 작업 내용 죄송합니다ㅠㅠ
* a9fa27180fc9220e31ed18bb2f3a89d5455afa79: APIManager가 400 대의 error를 감지하지 못하는 오류 수정 및 response debugPrint 작성.
  * 보기 힘든 중첩 if 로직을 탈출할 수 있는 좋은 로직은 언제든 환영입니다. ㅠㅠ
* d71151b290ca792c73d37527d95e33bcb236d371: struct 기본 생성자 가시성 public으로 변경.
  * Equtable 삭제 이유 : 참고 코드에 있어서 필요한가 싶어서 처음에 작성했지만 작성 이유가 현 adcio 코드에 필요없다고 판단파여 Equtable 프로토콜 상속은 삭제했습니다
* c4b275f430bdc98a9c216b3d3d1ffe2748828f46 : 첫 APIManager 코드 리펙토링
* 805920673a9cf3ca8fa810b65380b7b3492d44de : core 모듈 merge
* 6ec6e818545c559d650bf938a0e141f70e611346 : AdcioCore getter 적용
* c148c755c6c62a6173e1cf249313ba8874b0c3f3 : AdcioCore 가시성 관련 Hotfix 내용 Merge
* 1924a0c0c6f89098587a4e3e537409f7f121dd2e : network 결과를 Client 쪽에서 관리할 수 있도록 코드 수정
* c379ad3d703f1390bfeb4fd92cfc863eed599a8a : AdcioCore의 getter를 더욱 간단하게 코드 클린
 
## 로그
### 성공
![image](https://github.com/corca-ai/adcio-ios-sdk/assets/80940200/abfe0437-d68a-4a80-a911-85b41c7699ae)

### 실패
![image](https://github.com/corca-ai/adcio-ios-sdk/assets/80940200/1b0e72b4-77ac-49f4-a4c3-5a937888f834)

### Usage
```swift
try! AdcioAnalytics.shared.onPurchase(
    orderId: "SAMPLE ORDER ID",
    productIdOnStore: "SAMPLE PRODUCT ID ON STORE",
    amount: 123,
    baseUrl: BASE_URL,
    onSuccess: { data in
        debugPrint("Success onPurchase")
    },
    onFailure: { error in
        debugPrint("in Client : \(error)")
    }
)
```

## 다음 작업
* Placement PR 중 계속 개발